### PR TITLE
Fix experience timeline order

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,32 +47,72 @@
     <section id="experience" class="py-20 border-t" data-aos="fade-up">
       <div class="max-w-6xl mx-auto px-6">
         <h2 class="text-3xl font-bold mb-8 text-center">Experience</h2>
-        <div class="timeline relative">
-          <div class="absolute left-5 md:left-1/2 md:-translate-x-1/2 top-0 bottom-0 border-l-2 border-gray-300"></div>
-          <div class="timeline-item timeline-item-left md:pr-8 mb-16" data-aos="fade-left">
-            <h3 class="font-semibold">Head of Research</h3>
-            <p class="text-sm text-gray-500">Google AI Overviews and Search Result Page</p>
-            <p class="text-xs text-gray-400">Jun 2022 - Present</p>
+        <div class="relative">
+          <div class="absolute left-4 md:left-1/2 md:-translate-x-1/2 top-0 bottom-0 border-l-2 border-gray-300"></div>
+
+          <!-- Google -->
+          <div class="mb-16 md:grid grid-cols-9 items-start">
+            <div class="col-span-9 md:col-span-4 md:text-right md:pr-8" data-aos="fade-right">
+              <h3 class="font-semibold">Head of Research</h3>
+              <p class="text-sm text-gray-500">Google AI Overviews and Search Result Page</p>
+              <p class="text-xs text-gray-400">Jun 2022 - Present</p>
+            </div>
+            <div class="col-span-1 flex justify-center relative">
+              <span class="w-3 h-3 bg-emerald-600 rounded-full border-2 border-white absolute md:static left-0 md:left-1/2 md:-translate-x-1/2 mt-1"></span>
+            </div>
+            <div class="hidden md:block col-span-4"></div>
           </div>
-          <div class="timeline-item timeline-item-right md:pl-8 mb-16" data-aos="fade-right" data-aos-delay="100">
-            <h3 class="font-semibold">Research Manager</h3>
-            <p class="text-sm text-gray-500">Facebook</p>
-            <p class="text-xs text-gray-400">Nov 2018 - Jun 2022</p>
+
+          <!-- Facebook -->
+          <div class="mb-16 md:grid grid-cols-9 items-start">
+            <div class="hidden md:block col-span-4"></div>
+            <div class="col-span-1 flex justify-center relative">
+              <span class="w-3 h-3 bg-emerald-600 rounded-full border-2 border-white absolute md:static left-0 md:left-1/2 md:-translate-x-1/2 mt-1"></span>
+            </div>
+            <div class="col-span-9 md:col-span-4 md:pl-8" data-aos="fade-left" data-aos-delay="100">
+              <h3 class="font-semibold">Research Manager</h3>
+              <p class="text-sm text-gray-500">Facebook</p>
+              <p class="text-xs text-gray-400">Nov 2018 - Jun 2022</p>
+            </div>
           </div>
-          <div class="timeline-item timeline-item-left md:pr-8 mb-16" data-aos="fade-left" data-aos-delay="200">
-            <h3 class="font-semibold">Director, User Research and Analytics</h3>
-            <p class="text-sm text-gray-500">Salesforce</p>
-            <p class="text-xs text-gray-400">Nov 2017 - Nov 2018</p>
+
+          <!-- Salesforce -->
+          <div class="mb-16 md:grid grid-cols-9 items-start">
+            <div class="col-span-9 md:col-span-4 md:text-right md:pr-8" data-aos="fade-right" data-aos-delay="200">
+              <h3 class="font-semibold">Director, User Research and Analytics</h3>
+              <p class="text-sm text-gray-500">Salesforce</p>
+              <p class="text-xs text-gray-400">Nov 2017 - Nov 2018</p>
+            </div>
+            <div class="col-span-1 flex justify-center relative">
+              <span class="w-3 h-3 bg-emerald-600 rounded-full border-2 border-white absolute md:static left-0 md:left-1/2 md:-translate-x-1/2 mt-1"></span>
+            </div>
+            <div class="hidden md:block col-span-4"></div>
           </div>
-          <div class="timeline-item timeline-item-right md:pl-8 mb-16" data-aos="fade-right" data-aos-delay="300">
-            <h3 class="font-semibold">Researcher &amp; Research Manager</h3>
-            <p class="text-sm text-gray-500">Uber</p>
-            <p class="text-xs text-gray-400">July 2015 - Nov 2017</p>
+
+          <!-- Uber -->
+          <div class="mb-16 md:grid grid-cols-9 items-start">
+            <div class="hidden md:block col-span-4"></div>
+            <div class="col-span-1 flex justify-center relative">
+              <span class="w-3 h-3 bg-emerald-600 rounded-full border-2 border-white absolute md:static left-0 md:left-1/2 md:-translate-x-1/2 mt-1"></span>
+            </div>
+            <div class="col-span-9 md:col-span-4 md:pl-8" data-aos="fade-left" data-aos-delay="300">
+              <h3 class="font-semibold">Researcher &amp; Research Manager</h3>
+              <p class="text-sm text-gray-500">Uber</p>
+              <p class="text-xs text-gray-400">July 2015 - Nov 2017</p>
+            </div>
           </div>
-          <div class="timeline-item timeline-item-left md:pr-8 mb-16" data-aos="fade-left" data-aos-delay="400">
-            <h3 class="font-semibold">Researcher &amp; Lead Engineer</h3>
-            <p class="text-sm text-gray-500">General Electric</p>
-            <p class="text-xs text-gray-400">July 2013 - July 2015</p>
+
+          <!-- GE -->
+          <div class="mb-16 md:grid grid-cols-9 items-start">
+            <div class="col-span-9 md:col-span-4 md:text-right md:pr-8" data-aos="fade-right" data-aos-delay="400">
+              <h3 class="font-semibold">Researcher &amp; Lead Engineer</h3>
+              <p class="text-sm text-gray-500">General Electric</p>
+              <p class="text-xs text-gray-400">July 2013 - July 2015</p>
+            </div>
+            <div class="col-span-1 flex justify-center relative">
+              <span class="w-3 h-3 bg-emerald-600 rounded-full border-2 border-white absolute md:static left-0 md:left-1/2 md:-translate-x-1/2 mt-1"></span>
+            </div>
+            <div class="hidden md:block col-span-4"></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- redesign experience timeline using Tailwind grid layout
- keep entries ordered newest-to-oldest while still alternating left/right

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68511a32f170832b8f40871517019a36