### PR TITLE
Add single-page portfolio with timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,103 +4,140 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Anuj Tewari</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdn.tailwindcss.com">
   <link rel="stylesheet" href="https://unpkg.com/aos@2.3.1/dist/aos.css" />
+  <link rel="stylesheet" href="style.css">
   <style>html{scroll-behavior:smooth}</style>
 </head>
 <body class="text-gray-800">
   <main>
+    <!-- Hero -->
     <section id="hero" class="min-h-screen flex flex-col justify-center items-center text-center bg-gradient-to-b from-blue-800 via-blue-600 to-blue-400 text-white">
-      <img src="img/profile.jpg" alt="Anuj Tewari" class="w-40 h-40 rounded-full shadow-lg mb-6">
-      <h1 class="text-5xl font-bold mb-2">Anuj Tewari</h1>
-      <p class="text-xl mb-6">Head of Research, Google AI Overviews and Search Result Page</p>
+      <img src="img/profile.jpg" alt="Anuj Tewari" class="w-40 h-40 rounded-full shadow-lg mb-6" data-aos="zoom-in">
+      <h1 class="text-5xl font-bold mb-2" data-aos="fade-up">Anuj Tewari</h1>
+      <p class="text-xl mb-6" data-aos="fade-up" data-aos-delay="100">Head of Research, Google AI Overviews and Search Result Page</p>
+      <a href="mailto:anujtewari17@gmail.com" class="bg-blue-600 text-white px-8 py-3 rounded shadow hover:bg-blue-700" data-aos="fade-up" data-aos-delay="200">Email Me</a>
     </section>
 
+    <!-- About -->
     <section id="about" class="py-24 px-4">
       <div class="max-w-4xl mx-auto" data-aos="fade-up">
-        <h2 class="text-4xl font-semibold text-blue-600 mb-6">About</h2>
-        <p class="text-lg leading-relaxed">I am a computer scientist by training, with a cross-disciplinary background in Human Computer Interaction, Natural Language Processing and Education. I am experienced in building product research teams that use qualitative and quantitative data to generate actionable insights and influence product direction.</p>
+        <h2 class="text-4xl font-bold text-blue-600 mb-6">About</h2>
+        <p class="text-lg leading-relaxed mb-4">I am a computer scientist by training, with a cross-disciplinary background in Human Computer Interaction, Natural Language Processing and Education. I am experienced in building product research teams that use qualitative and quantitative data to generate actionable insights and influence product direction. Thanks for visiting my homepage!</p>
+        <p class="text-lg leading-relaxed">Contact: first name followed by last name followed by the number 17 at Gmail</p>
       </div>
     </section>
 
+    <!-- Experience -->
     <section id="experience" class="py-24 bg-gray-50 px-4">
       <div class="max-w-4xl mx-auto">
-        <h2 class="text-4xl font-semibold text-blue-600 mb-12" data-aos="fade-up">Experience</h2>
-        <div class="space-y-8">
-          <div class="flex flex-col md:flex-row md:justify-between" data-aos="fade-right">
-            <span class="font-medium">Head of Research – Google</span>
-            <span class="text-gray-600">2022–Present</span>
+        <h2 class="text-4xl font-bold text-blue-600 mb-12" data-aos="fade-up">Experience</h2>
+        <div class="timeline space-y-12">
+          <div class="timeline-item md:flex md:justify-between md:items-center" data-aos="fade-right">
+            <div class="md:w-5/12 md:text-right md:pr-8">
+              <h3 class="font-semibold">Head of Research, Google</h3>
+              <p class="text-sm text-gray-500">Jun 2022 – Present</p>
+            </div>
+            <div class="md:w-5/12"></div>
           </div>
-          <div class="flex flex-col md:flex-row md:justify-between" data-aos="fade-right">
-            <span class="font-medium">Research Manager – Facebook</span>
-            <span class="text-gray-600">2018–2022</span>
+          <div class="timeline-item md:flex md:justify-between md:items-center" data-aos="fade-left">
+            <div class="md:w-5/12"></div>
+            <div class="md:w-5/12 md:pl-8">
+              <h3 class="font-semibold">Research Manager, Facebook</h3>
+              <p class="text-sm text-gray-500">Nov 2018 – Jun 2022</p>
+            </div>
           </div>
-          <div class="flex flex-col md:flex-row md:justify-between" data-aos="fade-right">
-            <span class="font-medium">Director – Salesforce</span>
-            <span class="text-gray-600">2017–2018</span>
+          <div class="timeline-item md:flex md:justify-between md:items-center" data-aos="fade-right">
+            <div class="md:w-5/12 md:text-right md:pr-8">
+              <h3 class="font-semibold">Director, Salesforce</h3>
+              <p class="text-sm text-gray-500">Nov 2017 – Nov 2018</p>
+            </div>
+            <div class="md:w-5/12"></div>
           </div>
-          <div class="flex flex-col md:flex-row md:justify-between" data-aos="fade-right">
-            <span class="font-medium">Researcher – Uber</span>
-            <span class="text-gray-600">2015–2017</span>
+          <div class="timeline-item md:flex md:justify-between md:items-center" data-aos="fade-left">
+            <div class="md:w-5/12"></div>
+            <div class="md:w-5/12 md:pl-8">
+              <h3 class="font-semibold">Researcher, Uber</h3>
+              <p class="text-sm text-gray-500">Jul 2015 – Nov 2017</p>
+            </div>
           </div>
-          <div class="flex flex-col md:flex-row md:justify-between" data-aos="fade-right">
-            <span class="font-medium">Lead Engineer – GE</span>
-            <span class="text-gray-600">2013–2015</span>
+          <div class="timeline-item md:flex md:justify-between md:items-center" data-aos="fade-right">
+            <div class="md:w-5/12 md:text-right md:pr-8">
+              <h3 class="font-semibold">Lead Engineer, GE</h3>
+              <p class="text-sm text-gray-500">Jul 2013 – Jul 2015</p>
+            </div>
+            <div class="md:w-5/12"></div>
           </div>
         </div>
       </div>
     </section>
 
+    <!-- Education -->
     <section id="education" class="py-24 px-4">
       <div class="max-w-4xl mx-auto">
-        <h2 class="text-4xl font-semibold text-blue-600 mb-12" data-aos="fade-up">Education</h2>
-        <div class="space-y-8">
-          <div class="flex flex-col md:flex-row md:justify-between" data-aos="fade-left">
-            <span class="font-medium">PhD – UC Berkeley, Computer Science</span>
-            <span class="text-gray-600">2008–2013</span>
+        <h2 class="text-4xl font-bold text-blue-600 mb-12" data-aos="fade-up">Education</h2>
+        <div class="timeline space-y-12">
+          <div class="timeline-item md:flex md:justify-between md:items-center" data-aos="fade-left">
+            <div class="md:w-5/12"></div>
+            <div class="md:w-5/12 md:pl-8">
+              <h3 class="font-semibold">PhD – UC Berkeley, Computer Science</h3>
+              <p class="text-sm text-gray-500">2008–2013</p>
+            </div>
           </div>
-          <div class="flex flex-col md:flex-row md:justify-between" data-aos="fade-left">
-            <span class="font-medium">BTech – DAIICT, ICT</span>
-            <span class="text-gray-600">2004–2008</span>
+          <div class="timeline-item md:flex md:justify-between md:items-center" data-aos="fade-right">
+            <div class="md:w-5/12 md:text-right md:pr-8">
+              <h3 class="font-semibold">BTech – DA-IICT, ICT</h3>
+              <p class="text-sm text-gray-500">2004–2008</p>
+            </div>
+            <div class="md:w-5/12"></div>
           </div>
         </div>
       </div>
     </section>
 
+    <!-- Personal -->
     <section id="personal" class="py-24 bg-gray-50 px-4">
       <div class="max-w-4xl mx-auto" data-aos="fade-up">
-        <h2 class="text-4xl font-semibold text-blue-600 mb-6">Personal</h2>
-        <p class="text-lg leading-relaxed mb-4">Outside of work, I enjoy hiking, photography, reading, and playing video games. I live with my wife Devanshi, our two kids Parth and Anya, and our dog Milo.</p>
+        <h2 class="text-4xl font-bold text-blue-600 mb-6">Personal</h2>
+        <p class="text-lg leading-relaxed mb-4">Outside of work, I enjoy hiking, photography, reading, and playing video games. I live with my wife Devanshi, our kids Parth and Anya, and our dog Milo.</p>
         <p class="text-lg leading-relaxed">My brother <a href="https://ambujtewari.github.io/" class="text-blue-600 underline">Ambuj Tewari</a> is a professor in Statistics at the University of Michigan, Ann Arbor.</p>
       </div>
     </section>
 
+    <!-- Awards -->
     <section id="awards" class="py-24 px-4">
       <div class="max-w-4xl mx-auto">
-        <h2 class="text-4xl font-semibold text-blue-600 mb-12" data-aos="fade-up">Awards</h2>
-        <div class="grid gap-8 md:grid-cols-2">
-          <div class="bg-white p-6 shadow rounded hover:shadow-lg transition" data-aos="fade-up">
+        <h2 class="text-4xl font-bold text-blue-600 mb-12" data-aos="fade-up">Awards</h2>
+        <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          <div class="bg-white p-6 shadow rounded" data-aos="zoom-in">
             <p class="font-medium">Sigma Xi Member</p>
             <p class="text-gray-600">Since 2014</p>
           </div>
-          <div class="bg-white p-6 shadow rounded hover:shadow-lg transition" data-aos="fade-up" data-aos-delay="100">
+          <div class="bg-white p-6 shadow rounded" data-aos="zoom-in" data-aos-delay="100">
             <p class="font-medium">ACM SIGCHI Member</p>
             <p class="text-gray-600">Since 2010</p>
           </div>
-          <div class="bg-white p-6 shadow rounded hover:shadow-lg transition" data-aos="fade-up" data-aos-delay="200">
-            <p class="font-medium">CHI Best Paper Honorable Mention</p>
+          <div class="bg-white p-6 shadow rounded" data-aos="zoom-in" data-aos-delay="200">
+            <p class="font-medium">Samuel Silver Memorial Award</p>
           </div>
-          <div class="bg-white p-6 shadow rounded hover:shadow-lg transition" data-aos="fade-up" data-aos-delay="300">
-            <p class="font-medium">Big Ideas @ Berkeley Winner</p>
+          <div class="bg-white p-6 shadow rounded" data-aos="zoom-in" data-aos-delay="300">
+            <p class="font-medium">Big Ideas@Berkeley Winner</p>
+          </div>
+          <div class="bg-white p-6 shadow rounded" data-aos="zoom-in" data-aos-delay="400">
+            <p class="font-medium">Qualcomm Innovation Fellowship Finalist</p>
+          </div>
+          <div class="bg-white p-6 shadow rounded" data-aos="zoom-in" data-aos-delay="500">
+            <p class="font-medium">ACM CHI Best Paper Honorable Mention Winner</p>
           </div>
         </div>
       </div>
     </section>
 
+    <!-- Contact -->
     <section id="contact" class="py-24 bg-gray-50 px-4">
       <div class="max-w-4xl mx-auto text-center" data-aos="fade-up">
-        <h2 class="text-4xl font-semibold text-blue-600 mb-6">Contact</h2>
-        <p class="text-lg mb-6">Email: anujtewari17@gmail.com</p>
+        <h2 class="text-4xl font-bold text-blue-600 mb-6">Let’s Connect</h2>
+        <p class="text-lg mb-6">Email me: anujtewari17@gmail.com</p>
         <a href="mailto:anujtewari17@gmail.com" class="bg-blue-600 text-white px-8 py-3 rounded shadow hover:bg-blue-700">Email Me</a>
       </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,28 @@
+/* Custom styles for timeline */
+.timeline {
+  position: relative;
+}
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background-color: #e5e7eb; /* gray-200 */
+  transform: translateX(-50%);
+}
+.timeline-item {
+  position: relative;
+}
+.timeline-item::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 9999px;
+  background-color: #2563eb; /* blue-600 */
+  transform: translate(-50%, -50%);
+}


### PR DESCRIPTION
## Summary
- rewrite `index.html` with hero, about, experience, education, personal, awards, and contact sections
- implement alternating timelines and AOS animations
- create minimal `style.css` for the timeline line and dots

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685277195e88832bb588b303f0cc7916